### PR TITLE
Never logs due to if-in logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ Bugsnag.prototype.log = function (level, msg, meta, callback) {
     warn: 'warning'
   }
 
-  if (level in Object.keys(levelMapping)) {
+  if (level in levelMapping) {
     bugsnag.notify(msg, {
       severity: levelMapping[level]
     }, meta)


### PR DESCRIPTION
if(label in Object.keys(levelMapping)) isn't right.

According to this documentation of the in operator (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) in should be applied to an object if you are checking against a key. To perform an "in" operation on an array, you'd do it by index which doesn't apply here.
